### PR TITLE
Form layouts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ tasks.withType(Javadoc).all {
 }
 
 ext {
-    supportVersion = '27.0.2'
+    supportVersion = '27.1.1'
 }
 
 dependencies {

--- a/app/src/main/java/com/thejuki/kformmasterexample/CustomFormActivity.kt
+++ b/app/src/main/java/com/thejuki/kformmasterexample/CustomFormActivity.kt
@@ -3,9 +3,7 @@ package com.thejuki.kformmasterexample
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
-import com.thejuki.kformmaster.helper.FormBuildHelper
-import com.thejuki.kformmaster.helper.form
-import com.thejuki.kformmaster.helper.header
+import com.thejuki.kformmaster.helper.*
 import com.thejuki.kformmaster.listener.OnFormElementValueChangedListener
 import com.thejuki.kformmaster.model.BaseFormElement
 import com.thejuki.kformmasterexample.custom.helper.customEx
@@ -67,12 +65,25 @@ class CustomFormActivity : AppCompatActivity() {
             }
         }
 
-        formBuilder = form(this, recyclerView, listener, true) {
+        /**
+         * This form displays a custom form element in two ways:
+         *
+         * CustomEx - An entire custom form element: Layout, View, Model, State, and Helper
+         * textArea (FormLayouts) - textArea elements will use the form_element_custom layout
+         */
+        formBuilder = form(this, recyclerView, listener, formLayouts = FormLayouts(
+                textArea = R.layout.form_element_custom
+        )) {
             header { title = getString(R.string.custom_form) }
             customEx(Tag.Custom.ordinal) {
-                title = getString(R.string.Custom)
+                title = getString(R.string.Custom_Element)
             }
-            header { title = getString(R.string.custom_footer) }
+            header { title = getString(R.string.custom_footer_1) }
+            textArea(Tag.Custom.ordinal) {
+                title = getString(R.string.Custom_Layout)
+                maxLines = 4
+            }
+            header { title = getString(R.string.custom_footer_2) }
         }
 
         // IMPORTANT: Register your custom view binder or you will get a RuntimeException

--- a/app/src/main/java/com/thejuki/kformmasterexample/FormListenerActivity.kt
+++ b/app/src/main/java/com/thejuki/kformmasterexample/FormListenerActivity.kt
@@ -215,6 +215,6 @@ class FormListenerActivity : AppCompatActivity(), OnFormElementValueChangedListe
     }
 
     override fun onValueChanged(formElement: BaseFormElement<*>) {
-        Toast.makeText(this, formElement.value?.toString(), Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, formElement.valueAsString, Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/thejuki/kformmasterexample/FormListenerJavaActivity.java
+++ b/app/src/main/java/com/thejuki/kformmasterexample/FormListenerJavaActivity.java
@@ -18,6 +18,7 @@ import com.thejuki.kformmaster.helper.DateTimeBuilder;
 import com.thejuki.kformmaster.helper.DropDownBuilder;
 import com.thejuki.kformmaster.helper.EmailEditTextBuilder;
 import com.thejuki.kformmaster.helper.FormBuildHelper;
+import com.thejuki.kformmaster.helper.FormLayouts;
 import com.thejuki.kformmaster.helper.HeaderBuilder;
 import com.thejuki.kformmaster.helper.LabelBuilder;
 import com.thejuki.kformmaster.helper.MultiCheckBoxBuilder;
@@ -123,7 +124,12 @@ public class FormListenerJavaActivity extends AppCompatActivity implements OnFor
     }
 
     private void setupForm() {
-        formBuilder = new FormBuildHelper(this, this, findViewById(R.id.recyclerView), true);
+        FormLayouts formLayouts = new FormLayouts();
+
+        // Uncomment to replace all text elements with the form_element_custom layout
+        //formLayouts.setText(R.layout.form_element_custom);
+
+        formBuilder = new FormBuildHelper(this, this, findViewById(R.id.recyclerView), true, formLayouts);
 
         List<BaseFormElement<?>> elements = new ArrayList<>();
 

--- a/app/src/main/java/com/thejuki/kformmasterexample/FormListenerJavaActivity.java
+++ b/app/src/main/java/com/thejuki/kformmasterexample/FormListenerJavaActivity.java
@@ -307,8 +307,6 @@ public class FormListenerJavaActivity extends AppCompatActivity implements OnFor
 
     @Override
     public void onValueChanged(@NotNull BaseFormElement<?> formElement) {
-        Toast.makeText(this,
-                (formElement.getValue() != null) ? formElement.getValue().toString() : "",
-                Toast.LENGTH_SHORT).show();
+        Toast.makeText(this, formElement.getValueAsString(), Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/com/thejuki/kformmasterexample/FormTabbedActivity.kt
+++ b/app/src/main/java/com/thejuki/kformmasterexample/FormTabbedActivity.kt
@@ -7,7 +7,6 @@ import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentPagerAdapter
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
-import com.thejuki.kformmaster.helper.FormBuildHelper
 import com.thejuki.kformmasterexample.FormTabbedActivity.Tabs.Form
 import com.thejuki.kformmasterexample.FormTabbedActivity.Tabs.values
 import com.thejuki.kformmasterexample.fragment.FormFragment
@@ -22,8 +21,6 @@ import kotlinx.android.synthetic.main.activity_tabbed_form.*
  * @version 1.0
  */
 class FormTabbedActivity : AppCompatActivity() {
-
-    private lateinit var formBuilder: FormBuildHelper
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/thejuki/kformmasterexample/FullscreenFormActivity.kt
+++ b/app/src/main/java/com/thejuki/kformmasterexample/FullscreenFormActivity.kt
@@ -94,11 +94,11 @@ class FullscreenFormActivity : AppCompatActivity() {
     }
 
     private fun showHideAll() {
-        formBuilder.elements.forEach({
+        formBuilder.elements.forEach {
             if (it !is FormHeader) {
                 it.visible = !it.visible
             }
-        })
+        }
     }
 
     private fun validate() {
@@ -109,11 +109,11 @@ class FullscreenFormActivity : AppCompatActivity() {
         } else {
             alert.setTitle(this@FullscreenFormActivity.getString(R.string.FormInvalid))
 
-            formBuilder.elements.forEach({
+            formBuilder.elements.forEach {
                 if (!it.isValid) {
                     it.error = "This field is required!"
                 }
-            })
+            }
         }
 
         alert.setButton(AlertDialog.BUTTON_POSITIVE, this@FullscreenFormActivity.getString(android.R.string.ok), { _, _ -> })
@@ -161,7 +161,11 @@ class FullscreenFormActivity : AppCompatActivity() {
     }
 
     private fun setupForm() {
-        formBuilder = form(this, recyclerView, cacheForm = true) {
+        formBuilder = form(this, recyclerView,
+                formLayouts = FormLayouts(
+                        // Uncomment to replace all text elements with the form_element_custom layout
+                        //text = R.layout.form_element_custom
+                )) {
             header { title = getString(R.string.PersonalInfo); collapsible = true }
             email(Email.ordinal) {
                 title = getString(R.string.email)

--- a/app/src/main/java/com/thejuki/kformmasterexample/LoginFormActivity.kt
+++ b/app/src/main/java/com/thejuki/kformmasterexample/LoginFormActivity.kt
@@ -73,9 +73,8 @@ class LoginFormActivity : AppCompatActivity() {
     }
 
     private fun setupForm() {
-        // NOTE: Use autoMeasureEnabled when the layout_height of recyclerView is wrap_content
         formBuilder = FormBuildHelper(this, cacheForm = true)
-        formBuilder.attachRecyclerView(this, recyclerView, autoMeasureEnabled = true)
+        formBuilder.attachRecyclerView(this, recyclerView)
 
         val elements: MutableList<BaseFormElement<*>> = mutableListOf()
 

--- a/app/src/main/java/com/thejuki/kformmasterexample/TestFormActivity.kt
+++ b/app/src/main/java/com/thejuki/kformmasterexample/TestFormActivity.kt
@@ -5,12 +5,8 @@ import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
-import com.thejuki.kformmaster.helper.FormBuildHelper
-import com.thejuki.kformmaster.helper.form
-import com.thejuki.kformmaster.helper.header
-import com.thejuki.kformmaster.helper.number
+import com.thejuki.kformmaster.helper.*
 import com.thejuki.kformmaster.model.FormHeader
-import com.thejuki.kformmasterexample.item.ListItem
 import kotlinx.android.synthetic.main.activity_fullscreen_form.*
 
 /**
@@ -65,11 +61,11 @@ class TestFormActivity : AppCompatActivity() {
     }
 
     private fun showHideAll() {
-        formBuilder.elements.forEach({
+        formBuilder.elements.forEach {
             if (it !is FormHeader) {
                 it.visible = !it.visible
             }
-        })
+        }
     }
 
     private fun validate() {
@@ -80,11 +76,11 @@ class TestFormActivity : AppCompatActivity() {
         } else {
             alert.setTitle(this@TestFormActivity.getString(R.string.FormInvalid))
 
-            formBuilder.elements.forEach({
+            formBuilder.elements.forEach {
                 if (!it.isValid) {
                     it.error = "This field is required!"
                 }
-            })
+            }
         }
 
         alert.setButton(AlertDialog.BUTTON_POSITIVE, this@TestFormActivity.getString(android.R.string.ok), { _, _ -> })
@@ -102,14 +98,10 @@ class TestFormActivity : AppCompatActivity() {
         }
     }
 
-    private val fruits = listOf<ListItem>(ListItem(id = 1, name = "Banana"),
-            ListItem(id = 2, name = "Orange"),
-            ListItem(id = 3, name = "Mango"),
-            ListItem(id = 4, name = "Guava")
-    )
-
     private fun setupForm() {
-        formBuilder = form(this, recyclerView, cacheForm = true) {
+        formBuilder = form(this, recyclerView, formLayouts = FormLayouts(
+                number = R.layout.form_element_custom
+        )) {
             header { title = "A" }
             number {
                 title = "1"

--- a/app/src/main/java/com/thejuki/kformmasterexample/custom/view/FormCustomViewBinder.kt
+++ b/app/src/main/java/com/thejuki/kformmasterexample/custom/view/FormCustomViewBinder.kt
@@ -1,11 +1,8 @@
 package com.thejuki.kformmasterexample.custom.view
 
 import android.content.Context
-import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import com.github.vivchar.rendererrecyclerviewadapter.ViewHolder
@@ -38,18 +35,6 @@ class CustomViewBinder(private val context: Context, private val formBuilder: Fo
         editTextValue.setText(model.valueAsString)
         editTextValue.hint = model.hint ?: ""
 
-        setEditTextFocusEnabled(editTextValue, itemView)
-
-        editTextValue.setOnFocusChangeListener { _, hasFocus ->
-            if (hasFocus) {
-                textViewTitle.setTextColor(ContextCompat.getColor(context,
-                        R.color.colorFormMasterElementFocusedTitle))
-            } else {
-                textViewTitle.setTextColor(ContextCompat.getColor(context,
-                        R.color.colorFormMasterElementTextTitle))
-            }
-        }
-
         model.editView = editTextValue
 
         // Initially use 4 lines
@@ -58,25 +43,17 @@ class CustomViewBinder(private val context: Context, private val formBuilder: Fo
             model.maxLines = 4
         }
 
-        editTextValue.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(charSequence: CharSequence, i: Int, i2: Int, i3: Int) {}
+        // If an InputType is provided, use it instead
+        model.inputType?.let { editTextValue.setRawInputType(it) }
 
-            override fun onTextChanged(charSequence: CharSequence, i: Int, i2: Int, i3: Int) {
+        // If imeOptions are provided, use them instead of creating a new line
+        model.imeOptions?.let { editTextValue.imeOptions = it }
 
-                // get current form element, existing value and new value
-                val currentValue = model.valueAsString
-                val newValue = charSequence.toString()
+        setEditTextFocusEnabled(editTextValue, itemView)
+        setOnFocusChangeListener(context, model, formBuilder)
+        addTextChangedListener(model, formBuilder)
+        setOnEditorActionListener(model, formBuilder)
 
-                // trigger event only if the value is changed
-                if (currentValue != newValue) {
-                    model.setValue(newValue)
-                    model.error = null
-                    formBuilder.onValueChanged(model)
-                }
-            }
-
-            override fun afterTextChanged(editable: Editable) {}
-        })
     }, object : ViewStateProvider<FormCustomElement, ViewHolder> {
         override fun createViewStateID(model: FormCustomElement): Int {
             return model.id

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,8 @@
     <string name="CheckBox">CheckBox</string>
     <string name="TextView">Text View</string>
     <string name="Label">This is a label. The title takes up the whole row.</string>
-    <string name="Custom">Custom</string>
+    <string name="Custom_Element">Custom Element</string>
+    <string name="Custom_Layout">Custom Layout</string>
     <string name="Confirm">Clear Date field?</string>
     <string name="PersonalInfo">Personal Info</string>
     <string name="FamilyInfo">Family Info</string>
@@ -46,7 +47,8 @@
     <string name="login">login</string>
     <string name="custom_form">Custom form</string>
     <string name="tabbed_form">Tabbed form</string>
-    <string name="custom_footer">This is a custom field in the app project</string>
+    <string name="custom_footer_1">This is a custom element in the app project</string>
+    <string name="custom_footer_2">This is a custom layout in the app project</string>
     <string name="validate">Validate</string>
     <string name="clear">Clear</string>
     <string name="show_hide">Show/Hide</string>

--- a/docs/element/base.md
+++ b/docs/element/base.md
@@ -179,7 +179,7 @@ element.clear()
 ```
 
 ## Is the value valid?
-isValid contains a getter that checks if the valid is valid. At the base level, this checks if the value is not null or empty.
+isValid contains a getter that checks if the element is valid. At the base level, this checks if the value is not null or empty.
 This is used by formBuilder.isValidForm.
 ```kotlin
 element.isValid

--- a/docs/helper.md
+++ b/docs/helper.md
@@ -59,14 +59,11 @@ val elements: MutableList<BaseFormElement<*>> = mutableListOf()
 formBuilder.addFormElements(elements)
 ```
 
-### Auto Measure Enabled
-By default this is false.
-Enable autoMeasureEnabled when the layout_height of recyclerView is wrap_content such as the LoginFormActivity example.
-```kotlin
-formBuilder = FormBuildHelper(this, recyclerView, autoMeasureEnabled = true)
-```
+### Form Layouts
+Form Layouts override the default layouts used for all related form elements in the form.
 
 ```kotlin
-formBuilder = FormBuildHelper(this)
-formBuilder.attachRecyclerView(this, recyclerView, autoMeasureEnabled = true)
+ formBuilder = form(this, recyclerView, formLayouts = FormLayouts(
+                text = R.layout.form_element_custom,
+                textArea = R.layout.form_element_custom))
 ```

--- a/form/build.gradle
+++ b/form/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 27
-        versionCode 19
-        versionName "4.2.1"
+        versionCode 20
+        versionName "4.3.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -87,6 +87,7 @@ ext {
 
 dependencies {
     implementation "com.android.support:appcompat-v7:$supportVersion",
+            "com.android.support:design:$supportVersion",
             "com.android.support:recyclerview-v7:$supportVersion"
     api "com.github.vivchar:RendererRecyclerViewAdapter:$rendererRecyclerViewAdapterVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
@@ -107,7 +108,7 @@ publish {
     userOrg = 'thejuki'
     groupId = 'com.thejuki'
     artifactId = 'k-form-master'
-    publishVersion = '4.2.1'
+    publishVersion = '4.3.0'
     desc = 'Easily build generic forms with minimal effort (A Kotlin port of FormMaster)'
     website = 'https://github.com/TheJuki/KFormMaster'
 }

--- a/form/build.gradle
+++ b/form/build.gradle
@@ -75,7 +75,7 @@ tasks.withType(Javadoc).all {
 }
 
 ext {
-    supportVersion = '27.0.2'
+    supportVersion = '27.1.1'
     rendererRecyclerViewAdapterVersion = '2.5.0'
     tokenautocompleteVersion = '2.0.8'
     junitVersion = '4.12'

--- a/form/src/main/java/com/thejuki/kformmaster/helper/ElementDiffCallback.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/helper/ElementDiffCallback.kt
@@ -19,6 +19,4 @@ class ElementDiffCallback : DiffCallback<BaseFormElement<*>>() {
     override fun areContentsTheSame(oldItem: BaseFormElement<*>, newItem: BaseFormElement<*>): Boolean {
         return oldItem == newItem
     }
-
-
 }

--- a/form/src/main/java/com/thejuki/kformmaster/helper/FormBuildHelper.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/helper/FormBuildHelper.kt
@@ -23,7 +23,7 @@ import java.util.*
  */
 @FormDsl
 class FormBuildHelper
-@JvmOverloads constructor(context: Context, listener: OnFormElementValueChangedListener? = null, recyclerView: RecyclerView? = null, val cacheForm: Boolean = true, val formLayouts: FormLayouts) {
+@JvmOverloads constructor(context: Context, listener: OnFormElementValueChangedListener? = null, recyclerView: RecyclerView? = null, val cacheForm: Boolean = true, val formLayouts: FormLayouts? = null) {
 
     init {
         initializeFormBuildHelper(context, listener)
@@ -92,54 +92,54 @@ class FormBuildHelper
         this.formAdapter.setDiffCallback(ElementDiffCallback())
 
         // Header
-        this.formAdapter.registerRenderer(FormHeaderViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormHeaderViewBinder(context, this, formLayouts?.header).viewBinder)
 
         // Label
-        this.formAdapter.registerRenderer(FormLabelViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormLabelViewBinder(context, this, formLayouts?.label).viewBinder)
 
         // Edit Texts
         registerEditTexts(context)
 
         // AutoCompletes
-        this.formAdapter.registerRenderer(FormAutoCompleteViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormTokenAutoCompleteViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormAutoCompleteViewBinder(context, this, formLayouts?.autoComplete).viewBinder)
+        this.formAdapter.registerRenderer(FormTokenAutoCompleteViewBinder(context, this, formLayouts?.autoCompleteToken).viewBinder)
 
         // Button
-        this.formAdapter.registerRenderer(FormButtonViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormButtonViewBinder(context, this, formLayouts?.button).viewBinder)
 
         // Switch
-        this.formAdapter.registerRenderer(FormSwitchViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormSwitchViewBinder(context, this, formLayouts?.switch).viewBinder)
 
         // CheckBox
-        this.formAdapter.registerRenderer(FormCheckBoxViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormCheckBoxViewBinder(context, this, formLayouts?.checkBox).viewBinder)
 
         // Slider
-        this.formAdapter.registerRenderer(FormSliderViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormSliderViewBinder(context, this, formLayouts?.slider).viewBinder)
 
         // Pickers
         registerPickers(context)
 
         // Text View
-        this.formAdapter.registerRenderer(FormTextViewViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormTextViewViewBinder(context, this, formLayouts?.textView).viewBinder)
 
         this.listener = listener
     }
 
     private fun registerEditTexts(context: Context) {
-        this.formAdapter.registerRenderer(FormSingleLineEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormMultiLineEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormNumberEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormEmailEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormPhoneEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormPasswordEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormSingleLineEditTextViewBinder(context, this, formLayouts?.text).viewBinder)
+        this.formAdapter.registerRenderer(FormMultiLineEditTextViewBinder(context, this, formLayouts?.textArea).viewBinder)
+        this.formAdapter.registerRenderer(FormNumberEditTextViewBinder(context, this, formLayouts?.number).viewBinder)
+        this.formAdapter.registerRenderer(FormEmailEditTextViewBinder(context, this, formLayouts?.email).viewBinder)
+        this.formAdapter.registerRenderer(FormPhoneEditTextViewBinder(context, this, formLayouts?.phone).viewBinder)
+        this.formAdapter.registerRenderer(FormPasswordEditTextViewBinder(context, this, formLayouts?.password).viewBinder)
     }
 
     private fun registerPickers(context: Context) {
-        this.formAdapter.registerRenderer(FormPickerDateViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormPickerTimeViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormPickerDateTimeViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormPickerMultiCheckBoxViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
-        this.formAdapter.registerRenderer(FormPickerDropDownViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerDateViewBinder(context, this, formLayouts?.time).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerTimeViewBinder(context, this, formLayouts?.time).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerDateTimeViewBinder(context, this, formLayouts?.dateTime).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerMultiCheckBoxViewBinder(context, this, formLayouts?.multiCheckBox).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerDropDownViewBinder(context, this, formLayouts?.dropDown).viewBinder)
     }
 
     /**

--- a/form/src/main/java/com/thejuki/kformmaster/helper/FormBuildHelper.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/helper/FormBuildHelper.kt
@@ -23,13 +23,13 @@ import java.util.*
  */
 @FormDsl
 class FormBuildHelper
-@JvmOverloads constructor(context: Context, listener: OnFormElementValueChangedListener? = null, recyclerView: RecyclerView? = null, val cacheForm: Boolean = true, autoMeasureEnabled: Boolean = false) {
+@JvmOverloads constructor(context: Context, listener: OnFormElementValueChangedListener? = null, recyclerView: RecyclerView? = null, val cacheForm: Boolean = true, val formLayouts: FormLayouts) {
 
     init {
         initializeFormBuildHelper(context, listener)
 
         if (recyclerView != null) {
-            attachRecyclerView(context, recyclerView, autoMeasureEnabled)
+            attachRecyclerView(context, recyclerView)
         }
     }
 
@@ -92,54 +92,54 @@ class FormBuildHelper
         this.formAdapter.setDiffCallback(ElementDiffCallback())
 
         // Header
-        this.formAdapter.registerRenderer(FormHeaderViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormHeaderViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
 
         // Label
-        this.formAdapter.registerRenderer(FormLabelViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormLabelViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
 
         // Edit Texts
         registerEditTexts(context)
 
         // AutoCompletes
-        this.formAdapter.registerRenderer(FormAutoCompleteViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormTokenAutoCompleteViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormAutoCompleteViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormTokenAutoCompleteViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
 
         // Button
-        this.formAdapter.registerRenderer(FormButtonViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormButtonViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
 
         // Switch
-        this.formAdapter.registerRenderer(FormSwitchViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormSwitchViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
 
         // CheckBox
-        this.formAdapter.registerRenderer(FormCheckBoxViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormCheckBoxViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
 
         // Slider
-        this.formAdapter.registerRenderer(FormSliderViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormSliderViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
 
         // Pickers
         registerPickers(context)
 
         // Text View
-        this.formAdapter.registerRenderer(FormTextViewViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormTextViewViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
 
         this.listener = listener
     }
 
     private fun registerEditTexts(context: Context) {
-        this.formAdapter.registerRenderer(FormSingleLineEditTextViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormMultiLineEditTextViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormNumberEditTextViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormEmailEditTextViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormPhoneEditTextViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormPasswordEditTextViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormSingleLineEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormMultiLineEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormNumberEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormEmailEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormPhoneEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormPasswordEditTextViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
     }
 
     private fun registerPickers(context: Context) {
-        this.formAdapter.registerRenderer(FormPickerDateViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormPickerTimeViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormPickerDateTimeViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormPickerMultiCheckBoxViewBinder(context, this).viewBinder)
-        this.formAdapter.registerRenderer(FormPickerDropDownViewBinder(context, this).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerDateViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerTimeViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerDateTimeViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerMultiCheckBoxViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
+        this.formAdapter.registerRenderer(FormPickerDropDownViewBinder(context, this, formLayouts.headerLayoutID).viewBinder)
     }
 
     /**
@@ -152,13 +152,12 @@ class FormBuildHelper
     /**
      * Attaches the given [recyclerView] to form
      */
-    fun attachRecyclerView(context: Context, recyclerView: RecyclerView?, autoMeasureEnabled: Boolean = false) {
+    fun attachRecyclerView(context: Context, recyclerView: RecyclerView?) {
         recyclerView?.let {
             // Set up the RecyclerView with the adapter
             it.layoutManager = LinearLayoutManager(context).apply {
                 orientation = LinearLayoutManager.VERTICAL
                 stackFromEnd = false
-                isAutoMeasureEnabled = autoMeasureEnabled
             }
             it.adapter = formAdapter
             it.itemAnimator = DefaultItemAnimator()

--- a/form/src/main/java/com/thejuki/kformmaster/helper/FormBuilder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/helper/FormBuilder.kt
@@ -29,12 +29,14 @@ fun form(context: Context,
          recyclerView: RecyclerView,
          listener: OnFormElementValueChangedListener? = null,
          cacheForm: Boolean = true,
+         formLayouts: FormLayouts? = null,
          init: FormBuildHelper.() -> Unit): FormBuildHelper {
     val form = FormBuildHelper(
             context = context,
             listener = listener,
             recyclerView = recyclerView,
-            cacheForm = cacheForm
+            cacheForm = cacheForm,
+            formLayouts = formLayouts
     )
     form.init()
     form.setItems()

--- a/form/src/main/java/com/thejuki/kformmaster/helper/FormLayouts.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/helper/FormLayouts.kt
@@ -11,4 +11,23 @@ import android.support.annotation.LayoutRes
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormLayouts(@LayoutRes val headerLayoutID: Int? = null)
+class FormLayouts(@LayoutRes var header: Int? = null,
+                  @LayoutRes var text: Int? = null,
+                  @LayoutRes var textArea: Int? = null,
+                  @LayoutRes var number: Int? = null,
+                  @LayoutRes var email: Int? = null,
+                  @LayoutRes var password: Int? = null,
+                  @LayoutRes var phone: Int? = null,
+                  @LayoutRes var autoComplete: Int? = null,
+                  @LayoutRes var autoCompleteToken: Int? = null,
+                  @LayoutRes var button: Int? = null,
+                  @LayoutRes var date: Int? = null,
+                  @LayoutRes var time: Int? = null,
+                  @LayoutRes var dateTime: Int? = null,
+                  @LayoutRes var dropDown: Int? = null,
+                  @LayoutRes var multiCheckBox: Int? = null,
+                  @LayoutRes var switch: Int? = null,
+                  @LayoutRes var checkBox: Int? = null,
+                  @LayoutRes var slider: Int? = null,
+                  @LayoutRes var label: Int? = null,
+                  @LayoutRes var textView: Int? = null)

--- a/form/src/main/java/com/thejuki/kformmaster/helper/FormLayouts.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/helper/FormLayouts.kt
@@ -1,0 +1,14 @@
+package com.thejuki.kformmaster.helper
+
+import android.support.annotation.LayoutRes
+
+/**
+ * Form Layouts
+ *
+ * This class can override the form element layouts at the form level.
+ * Each related form element in the form will use these layouts, if specified.
+ *
+ * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
+ * @version 1.0
+ */
+class FormLayouts(@LayoutRes val headerLayoutID: Int? = null)

--- a/form/src/main/java/com/thejuki/kformmaster/model/BaseFormElement.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/model/BaseFormElement.kt
@@ -1,5 +1,6 @@
 package com.thejuki.kformmaster.model
 
+import android.content.res.ColorStateList
 import android.support.v7.widget.*
 import android.text.InputType
 import android.view.Gravity
@@ -180,6 +181,11 @@ open class BaseFormElement<T>(var tag: Int = -1) : ViewModel {
                 it.text = title
             }
         }
+
+    /**
+     * Form Element Title View Text Colors
+     */
+    var titleViewTextColors: ColorStateList? = null
 
     /**
      * Form Element Error View

--- a/form/src/main/java/com/thejuki/kformmaster/view/BaseFormViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/BaseFormViewBinder.kt
@@ -2,6 +2,7 @@ package com.thejuki.kformmaster.view
 
 import android.app.Dialog
 import android.content.Context
+import android.content.res.ColorStateList
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
@@ -54,13 +55,26 @@ abstract class BaseFormViewBinder {
      * Sets the focus changed listener on the editView to update the form element value
      */
     fun setOnFocusChangeListener(context: Context, formElement: BaseFormElement<*>, formBuilder: FormBuildHelper) {
+        if (formElement.titleViewTextColors == null) {
+            val states = arrayOf(intArrayOf(android.R.attr.state_focused), intArrayOf())
+            val colors = intArrayOf(ContextCompat.getColor(context,
+                    R.color.colorFormMasterElementFocusedTitle),
+                    formElement.titleView?.textColors?.getColorForState(intArrayOf(),
+                            (ContextCompat.getColor(context, R.color.colorFormMasterElementTextTitle)))
+                            ?: -1
+            )
+            formElement.titleViewTextColors = ColorStateList(states, colors)
+            formElement.titleView?.setTextColor(formElement.titleViewTextColors)
+        }
         formElement.editView?.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
-                formElement.titleView?.setTextColor(ContextCompat.getColor(context,
-                        R.color.colorFormMasterElementFocusedTitle))
+                formElement.titleView?.setTextColor(formElement.titleViewTextColors?.getColorForState(intArrayOf(android.R.attr.state_focused),
+                        (ContextCompat.getColor(context, R.color.colorFormMasterElementFocusedTitle)))
+                        ?: -1)
             } else {
-                formElement.titleView?.setTextColor(ContextCompat.getColor(context,
-                        R.color.colorFormMasterElementTextTitle))
+                formElement.titleView?.setTextColor(formElement.titleViewTextColors?.getColorForState(intArrayOf(),
+                        (ContextCompat.getColor(context, R.color.colorFormMasterElementTextTitle)))
+                        ?: -1)
 
                 (formElement.editView as? AppCompatEditText)?.let {
                     if (it.text.toString() != formElement.valueAsString) {

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormAutoCompleteViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormAutoCompleteViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatAutoCompleteTextView
 import android.support.v7.widget.AppCompatTextView
@@ -25,8 +26,9 @@ import com.thejuki.kformmaster.state.FormAutoCompleteViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormAutoCompleteViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element_auto_complete, FormAutoCompleteElement::class.java, { model, finder, _ ->
+class FormAutoCompleteViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element_auto_complete, FormAutoCompleteElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormButtonViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormButtonViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.view.View
 import android.widget.Button
 import com.github.vivchar.rendererrecyclerviewadapter.ViewHolder
@@ -20,8 +21,9 @@ import com.thejuki.kformmaster.state.FormButtonViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormButtonViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element_button, FormButtonElement::class.java, { model, finder, _ ->
+class FormButtonViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element_button, FormButtonElement::class.java, { model, finder, _ ->
         val itemView = finder.getRootView() as View
         baseSetup(model, null, null, itemView)
 

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormCheckBoxViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormCheckBoxViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatCheckBox
 import android.support.v7.widget.AppCompatTextView
 import android.view.View
@@ -21,8 +22,9 @@ import com.thejuki.kformmaster.state.FormCheckBoxViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormCheckBoxViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element_checkbox, FormCheckBoxElement::class.java, { model, finder, _ ->
+class FormCheckBoxViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element_checkbox, FormCheckBoxElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormEmailEditTextViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormEmailEditTextViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -24,8 +25,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormEmailEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormEmailEditTextElement::class.java, { model, finder, _ ->
+class FormEmailEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormEmailEditTextElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormHeaderViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormHeaderViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatTextView
 import android.view.View
 import com.github.vivchar.rendererrecyclerviewadapter.ViewHolder
@@ -20,8 +21,9 @@ import com.thejuki.kformmaster.state.FormHeaderViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormHeaderViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element_header, FormHeader::class.java, { model, finder, _ ->
+class FormHeaderViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element_header, FormHeader::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val itemView = finder.getRootView() as View
         baseSetup(model, textViewTitle, null, itemView)

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormLabelViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormLabelViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatTextView
 import android.view.View
 import com.github.vivchar.rendererrecyclerviewadapter.ViewHolder
@@ -20,8 +21,9 @@ import com.thejuki.kformmaster.state.FormLabelViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormLabelViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element_label, FormLabelElement::class.java, { model, finder, _ ->
+class FormLabelViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element_label, FormLabelElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val itemView = finder.getRootView() as View
         baseSetup(model, textViewTitle, null, itemView)

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormMultiLineEditTextViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormMultiLineEditTextViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.view.View
@@ -22,8 +23,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormMultiLineEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormMultiLineEditTextElement::class.java, { model, finder, _ ->
+class FormMultiLineEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormMultiLineEditTextElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormNumberEditTextViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormNumberEditTextViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -23,8 +24,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormNumberEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormNumberEditTextElement::class.java, { model, finder, _ ->
+class FormNumberEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormNumberEditTextElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPasswordEditTextViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPasswordEditTextViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -23,8 +24,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormPasswordEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormPasswordEditTextElement::class.java, { model, finder, _ ->
+class FormPasswordEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormPasswordEditTextElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPhoneEditTextViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPhoneEditTextViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -23,8 +24,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormPhoneEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormPhoneEditTextElement::class.java, { model, finder, _ ->
+class FormPhoneEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormPhoneEditTextElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPickerDateTimeViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPickerDateTimeViewBinder.kt
@@ -52,7 +52,7 @@ class FormPickerDateTimeViewBinder(private val context: Context, private val for
         }
 
         val datePickerDialog = DatePickerDialog(context,
-                dateDialogListener(model, editTextValue, textViewError),
+                dateDialogListener(model, editTextValue),
                 model.value?.year ?: 0,
                 if ((model.value?.month ?: 0) == 0) 0 else (model.value?.month ?: 0) - 1,
                 model.value?.dayOfMonth ?: 0)
@@ -69,8 +69,7 @@ class FormPickerDateTimeViewBinder(private val context: Context, private val for
     })
 
     private fun dateDialogListener(model: FormPickerDateTimeElement,
-                                   editTextValue: AppCompatEditText,
-                                   textViewError: AppCompatTextView): DatePickerDialog.OnDateSetListener {
+                                   editTextValue: AppCompatEditText): DatePickerDialog.OnDateSetListener {
         return DatePickerDialog.OnDateSetListener { _, year, monthOfYear, dayOfMonth ->
             // get current form element, existing value and new value
 

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPickerDateTimeViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPickerDateTimeViewBinder.kt
@@ -3,6 +3,7 @@ package com.thejuki.kformmaster.view
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -24,8 +25,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormPickerDateTimeViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormPickerDateTimeElement::class.java, { model, finder, _ ->
+class FormPickerDateTimeViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormPickerDateTimeElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPickerDateViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPickerDateViewBinder.kt
@@ -2,6 +2,7 @@ package com.thejuki.kformmaster.view
 
 import android.app.DatePickerDialog
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -23,8 +24,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormPickerDateViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormPickerDateElement::class.java, { model, finder, _ ->
+class FormPickerDateViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormPickerDateElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPickerDropDownViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPickerDropDownViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -22,8 +23,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormPickerDropDownViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormPickerDropDownElement::class.java, { model, finder, _ ->
+class FormPickerDropDownViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormPickerDropDownElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPickerMultiCheckBoxViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPickerMultiCheckBoxViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -22,8 +23,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormPickerMultiCheckBoxViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormPickerMultiCheckBoxElement::class.java, { model, finder, _ ->
+class FormPickerMultiCheckBoxViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormPickerMultiCheckBoxElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPickerTimeViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPickerTimeViewBinder.kt
@@ -2,6 +2,7 @@ package com.thejuki.kformmaster.view
 
 import android.app.TimePickerDialog
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.text.InputType
@@ -23,8 +24,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormPickerTimeViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormPickerTimeElement::class.java, { model, finder, _ ->
+class FormPickerTimeViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormPickerTimeElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormSingleLineEditTextViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormSingleLineEditTextViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
 import android.view.View
@@ -22,8 +23,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormSingleLineEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormSingleLineEditTextElement::class.java, { model, finder, _ ->
+class FormSingleLineEditTextViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormSingleLineEditTextElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormSliderViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormSliderViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatSeekBar
 import android.support.v7.widget.AppCompatTextView
 import android.view.View
@@ -23,8 +24,9 @@ import kotlin.math.roundToInt
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormSliderViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element_slider, FormSliderElement::class.java, { model, finder, _ ->
+class FormSliderViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element_slider, FormSliderElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormSwitchViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormSwitchViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v7.widget.AppCompatTextView
 import android.support.v7.widget.SwitchCompat
 import android.view.View
@@ -21,8 +22,9 @@ import com.thejuki.kformmaster.state.FormSwitchViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormSwitchViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element_switch, FormSwitchElement::class.java, { model, finder, _ ->
+class FormSwitchViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element_switch, FormSwitchElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormTextViewViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormTextViewViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatEditText
 import android.support.v7.widget.AppCompatTextView
@@ -23,8 +24,9 @@ import com.thejuki.kformmaster.state.FormEditTextViewState
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormTextViewViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element, FormTextViewElement::class.java, { model, finder, _ ->
+class FormTextViewViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element, FormTextViewElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormTokenAutoCompleteViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormTokenAutoCompleteViewBinder.kt
@@ -1,6 +1,7 @@
 package com.thejuki.kformmaster.view
 
 import android.content.Context
+import android.support.annotation.LayoutRes
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.AppCompatTextView
 import android.view.View
@@ -25,8 +26,9 @@ import com.tokenautocomplete.TokenCompleteTextView
  * @author **TheJuki** ([GitHub](https://github.com/TheJuki))
  * @version 1.0
  */
-class FormTokenAutoCompleteViewBinder(private val context: Context, private val formBuilder: FormBuildHelper) : BaseFormViewBinder() {
-    var viewBinder = ViewBinder(R.layout.form_element_token_auto_complete, FormTokenAutoCompleteElement::class.java, { model, finder, _ ->
+class FormTokenAutoCompleteViewBinder(private val context: Context, private val formBuilder: FormBuildHelper, @LayoutRes private val layoutID: Int?) : BaseFormViewBinder() {
+    var viewBinder = ViewBinder(layoutID
+            ?: R.layout.form_element_token_auto_complete, FormTokenAutoCompleteElement::class.java, { model, finder, _ ->
         val textViewTitle = finder.find(R.id.formElementTitle) as AppCompatTextView
         val textViewError = finder.find(R.id.formElementError) as AppCompatTextView
         val itemView = finder.getRootView() as View

--- a/form/src/test/java/com/thejuki/kformmaster/CustomGen.kt
+++ b/form/src/test/java/com/thejuki/kformmaster/CustomGen.kt
@@ -96,6 +96,16 @@ interface CustomGen {
         }
 
         /**
+         * Generates a formLabelElement
+         */
+        fun formLabelElement() = object : Gen<FormLabelElement> {
+            override fun generate(): FormLabelElement {
+                return FormLabelElement()
+                        .setTitle(Gen.string().generate()) as FormLabelElement
+            }
+        }
+
+        /**
          * Generates a FormPickerDropDownElement
          */
         fun formPickerDropDownElement() = object : Gen<FormPickerDropDownElement<String>> {

--- a/form/src/test/java/com/thejuki/kformmaster/FormModelUnitTest.kt
+++ b/form/src/test/java/com/thejuki/kformmaster/FormModelUnitTest.kt
@@ -34,6 +34,12 @@ class FormModelUnitTest : ShouldSpec() {
             }
         }
 
+        "Label" {
+            should("have valid formHeader") {
+                CustomGen.formLabelElement().generate().title shouldNotBe null
+            }
+        }
+
         "TextView" {
             should("have valid formTextViewElement") {
                 val element = CustomGen.formTextViewElement().generate()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ pages:
   - Custom:
     - 'Customize Form': 'custom/customize.md'
     - 'Custom Element': 'custom/element.md'
+    - 'Form Layouts': 'custom/formLayouts.md'
   - About:
     - 'Contributing': 'about/contributing.md'
     - 'Credits': 'about/credits.md'


### PR DESCRIPTION
### Goals
Create FormLayouts class to override the default layouts used for all related form elements in the form.

### Implementation Details
The view binders are modified to accept a @LayoutRes value which is provided by the FormBuildHelper during initializeFormBuildHelper. If provided, the default layoutID will be overridden by the user provided layoutID.

### Testing Details
Manual testing. CustomFormActivity is used to show the differences between a custom form element and just using a custom layout on an existing form element.
