### PR TITLE
Easier way to display value for DropDown with custom object

### DIFF
--- a/form/src/main/java/com/thejuki/kformmaster/model/BaseFormElement.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/model/BaseFormElement.kt
@@ -608,7 +608,7 @@ open class BaseFormElement<T>(var tag: Int = -1) : ViewModel {
     /**
      * Form Element Value String value
      */
-    val valueAsString: String
+    open val valueAsString: String
         get() = this.value?.toString() ?: ""
 
     /**

--- a/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
@@ -77,9 +77,12 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
      * DisplayValueFor
      *  Used to specify a string value to be displayed
      */
-    var displayValueFor: ((T?) -> String?) = {
-        it.toString()
+    var displayValueFor: ((T?) -> String) = {
+        it?.toString() ?: ""
     }
+
+    override val valueAsString: String
+        get() =  this.displayValueFor(this.value)
 
     /**
      * Re-initializes the dialog
@@ -132,21 +135,21 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
                     if (displayRadioButtons) {
                         it.setSingleChoiceItems(this, selectedIndex) { dialogInterface, which ->
                             this@FormPickerDropDownElement.error = null
-                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(this.getItem(which) as T))
+                            editTextView?.setText(this.getItem(which)?.toString())
                             this@FormPickerDropDownElement.setValue(this.getItem(which))
                             listener?.onValueChanged(this@FormPickerDropDownElement)
 
-                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(this.getItem(which) as T))
+                            editTextView?.setText(this@FormPickerDropDownElement.valueAsString)
                             dialogInterface.dismiss()
                         }
                     } else {
                         it.setAdapter(this) { _, which ->
                             this@FormPickerDropDownElement.error = null
-                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(this.getItem(which) as T))
+                            editTextView?.setText(this.getItem(which)?.toString())
                             this@FormPickerDropDownElement.setValue(this.getItem(which))
                             listener?.onValueChanged(this@FormPickerDropDownElement)
 
-                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(this.getItem(which) as T))
+                            editTextView?.setText(this@FormPickerDropDownElement.valueAsString)
                         }
                     }
                 }
@@ -161,26 +164,26 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
                     if (displayRadioButtons) {
                         it.setSingleChoiceItems(options, selectedIndex) { dialogInterface, which ->
                             this.error = null
-                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(options[which] as T))
+                            editTextView?.setText(options[which])
 
                             this.options?.let { option ->
                                 this.setValue(option[which])
                             }
                             listener?.onValueChanged(this)
 
-                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(options[which] as T))
+                            editTextView?.setText(this.valueAsString)
                             dialogInterface.dismiss()
                         }
                     } else {
                         it.setItems(options) { _, which ->
                             this.error = null
-                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(options[which] as T))
+                            editTextView?.setText(options[which])
                             this.options?.let { option ->
                                 this.setValue(option[which])
                             }
                             listener?.onValueChanged(this)
 
-                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(options[which] as T))
+                            editTextView?.setText(this.valueAsString)
                         }
                     }
                 }

--- a/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
@@ -77,12 +77,12 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
      * DisplayValueFor
      *  Used to specify a string value to be displayed
      */
-    var displayValueFor: ((T?) -> String) = {
+    var displayValueFor: ((T?) -> String?) = {
         it?.toString() ?: ""
     }
 
     override val valueAsString: String
-        get() =  this.displayValueFor(this.value)
+        get() =  this.displayValueFor(this.value) ?: ""
 
     /**
      * Re-initializes the dialog

--- a/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
@@ -74,9 +74,16 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
     var theme: Int = 0
 
     /**
+     * DisplayValueFor
+     *  (optional - used to specify a string value to be displayed)
+     */
+    var displayValueFor: ((T?) -> String?)? = null
+
+    /**
      * Re-initializes the dialog
      * Should be called after the options list changes
      */
+    @Suppress("UNCHECKED_CAST")
     fun reInitDialog(formBuilder: FormBuildHelper? = null) {
         // reformat the options in format needed
         val options = arrayOfNulls<CharSequence>(this.options?.size ?: 0)
@@ -84,7 +91,11 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
 
         this.options?.let {
             for (i in it.indices) {
-                options[i] = it[i].toString()
+                if (this.displayValueFor != null) {
+                    options[i] = this.displayValueFor?.invoke(it[i])
+                } else {
+                    options[i] = it[i].toString()
+                }
             }
         }
 
@@ -123,7 +134,11 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
                     if (displayRadioButtons) {
                         it.setSingleChoiceItems(this, selectedIndex) { dialogInterface, which ->
                             this@FormPickerDropDownElement.error = null
-                            editTextView?.setText(this.getItem(which)?.toString())
+                            if (this@FormPickerDropDownElement.displayValueFor != null) {
+                                editTextView?.setText(this@FormPickerDropDownElement.displayValueFor?.invoke(this.getItem(which) as T))
+                            } else {
+                                editTextView?.setText(this.getItem(which)?.toString())
+                            }
                             this@FormPickerDropDownElement.setValue(this.getItem(which))
                             listener?.onValueChanged(this@FormPickerDropDownElement)
 
@@ -133,7 +148,11 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
                     } else {
                         it.setAdapter(this) { _, which ->
                             this@FormPickerDropDownElement.error = null
-                            editTextView?.setText(this.getItem(which)?.toString())
+                            if (this@FormPickerDropDownElement.displayValueFor != null) {
+                                editTextView?.setText(this@FormPickerDropDownElement.displayValueFor?.invoke(this.getItem(which) as T))
+                            } else {
+                                editTextView?.setText(this.getItem(which)?.toString())
+                            }
                             this@FormPickerDropDownElement.setValue(this.getItem(which))
                             listener?.onValueChanged(this@FormPickerDropDownElement)
 
@@ -197,3 +216,4 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
         editTextView?.setOnClickListener(listener)
     }
 }
+

--- a/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
@@ -75,9 +75,11 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
 
     /**
      * DisplayValueFor
-     *  (optional - used to specify a string value to be displayed)
+     *  Used to specify a string value to be displayed
      */
-    var displayValueFor: ((T?) -> String?)? = null
+    var displayValueFor: ((T?) -> String?) = {
+        it.toString()
+    }
 
     /**
      * Re-initializes the dialog
@@ -91,11 +93,7 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
 
         this.options?.let {
             for (i in it.indices) {
-                if (this.displayValueFor != null) {
-                    options[i] = this.displayValueFor?.invoke(it[i])
-                } else {
-                    options[i] = it[i].toString()
-                }
+                options[i] = this.displayValueFor(it[i])
             }
         }
 
@@ -134,29 +132,21 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
                     if (displayRadioButtons) {
                         it.setSingleChoiceItems(this, selectedIndex) { dialogInterface, which ->
                             this@FormPickerDropDownElement.error = null
-                            if (this@FormPickerDropDownElement.displayValueFor != null) {
-                                editTextView?.setText(this@FormPickerDropDownElement.displayValueFor?.invoke(this.getItem(which) as T))
-                            } else {
-                                editTextView?.setText(this.getItem(which)?.toString())
-                            }
+                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(this.getItem(which) as T))
                             this@FormPickerDropDownElement.setValue(this.getItem(which))
                             listener?.onValueChanged(this@FormPickerDropDownElement)
 
-                            editTextView?.setText(this@FormPickerDropDownElement.valueAsString)
+                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(this.getItem(which) as T))
                             dialogInterface.dismiss()
                         }
                     } else {
                         it.setAdapter(this) { _, which ->
                             this@FormPickerDropDownElement.error = null
-                            if (this@FormPickerDropDownElement.displayValueFor != null) {
-                                editTextView?.setText(this@FormPickerDropDownElement.displayValueFor?.invoke(this.getItem(which) as T))
-                            } else {
-                                editTextView?.setText(this.getItem(which)?.toString())
-                            }
+                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(this.getItem(which) as T))
                             this@FormPickerDropDownElement.setValue(this.getItem(which))
                             listener?.onValueChanged(this@FormPickerDropDownElement)
 
-                            editTextView?.setText(this@FormPickerDropDownElement.valueAsString)
+                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(this.getItem(which) as T))
                         }
                     }
                 }
@@ -171,25 +161,26 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
                     if (displayRadioButtons) {
                         it.setSingleChoiceItems(options, selectedIndex) { dialogInterface, which ->
                             this.error = null
-                            editTextView?.setText(options[which])
+                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(options[which] as T))
+
                             this.options?.let { option ->
                                 this.setValue(option[which])
                             }
                             listener?.onValueChanged(this)
 
-                            editTextView?.setText(this.valueAsString)
+                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(options[which] as T))
                             dialogInterface.dismiss()
                         }
                     } else {
                         it.setItems(options) { _, which ->
                             this.error = null
-                            editTextView?.setText(options[which])
+                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(options[which] as T))
                             this.options?.let { option ->
                                 this.setValue(option[which])
                             }
                             listener?.onValueChanged(this)
 
-                            editTextView?.setText(this.valueAsString)
+                            editTextView?.setText(this@FormPickerDropDownElement.displayValueFor(options[which] as T))
                         }
                     }
                 }


### PR DESCRIPTION
Instead of creating a custom ListItem with id and name and overriding toString method, I propose we set a displayValueFor property to define the value of each option (you don't need to override toString anymore nor do anything else!), it's a block and you use it like this:

**Example 1 (Custom Object)**

```
dropDown<CustomObject>(1) {
    dialogTitle = "Select One"
    options = myCustomObjectList
    value = myCustomObject
	displayValueFor = {
        it.myCustomProperty
    }
}
```
**Example 2**

```
data class ListItem(val id: Long? = null,
                    val name: String? = null
) {}

dropDown<ListItem>(1) {
    dialogTitle = "Select One"
    options = listOf(ListItem(id = 1, name = "50"),
                     ListItem(id = 2, name = "100"))
    value = ListItem(id = 1, name = "Banana")
	displayValueFor = {
		//all examples below will work!
        it?.name
        //it?.id?.toString()
        //it?.name + "km per hour"
        //it?.name + "(" + it?.id?.toString() + ")"
        //"Something else!"
    }
}
```

It's worth to mention that the current way you made will keep working as it is, meaning it won't break for current users

```
dropDown<ListItem>(1) {
    dialogTitle = "Select One"
    options = listOf(ListItem(id = 1, name = "Banana"),
                     ListItem(id = 2, name = "Orange"))
    value = ListItem(id = 1, name = "Banana")
}
```