### PR TITLE
added an override for FormPickerMultiCheckBoxElement output string generation

### DIFF
--- a/app/src/main/java/com/thejuki/kformmasterexample/FullscreenFormActivity.kt
+++ b/app/src/main/java/com/thejuki/kformmasterexample/FullscreenFormActivity.kt
@@ -158,7 +158,11 @@ class FullscreenFormActivity : AppCompatActivity() {
             ListItem(id = 2, name = "Orange"),
             ListItem(id = 3, name = "Mango"),
             ListItem(id = 4, name = "Guava"),
-            ListItem(id = 5, name = "Apple")
+            ListItem(id = 5, name = "Apple"),
+            ListItem(id = 6, name = "Dragon Fruit"),
+            ListItem(id = 7, name = "Star Fruit"),
+            ListItem(id = 8, name = "Watermelon"),
+            ListItem(id = 9, name = "Honeydew")
     )
 
     private val fruitsSegmented = listOf(SegmentedListItem(id = 1, name = "Banana", drawableDirection = FormSegmentedElement.DrawableDirection.Top),
@@ -475,6 +479,30 @@ class FullscreenFormActivity : AppCompatActivity() {
                 clearable = true
                 valueObservers.add { newValue, element ->
                     Toast.makeText(this@FullscreenFormActivity, newValue.toString(), LENGTH_SHORT).show()
+                }
+            }
+            multiCheckBox<List<ListItem>>(MultiItems.ordinal) {
+                title = getString(R.string.MultiItemsWithOverride)
+                dialogTitle = getString(R.string.MultiItems)
+                theme = R.style.CustomDialogPicker
+                options = fruits
+                enabled = true
+                maxLines = 1
+                rightToLeft = false
+                displayDivider = false
+                value = listOf()
+                required = true
+                clearable = true
+                valueObservers.add { newValue, element ->
+                    Toast.makeText(this@FullscreenFormActivity, newValue.toString(), LENGTH_SHORT).show()
+                }
+                valueAsStringOverride = { values ->
+                    when {
+                        values.isNullOrEmpty() -> "No fruit selected"
+                        values.size == options?.size -> "All fruits selected"
+                        values.size > 3 -> "${values.size} fruits selected"
+                        else -> null
+                    }
                 }
             }
             autoComplete<ContactItem>(AutoCompleteElement.ordinal) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="DateTime">Date Time</string>
     <string name="SingleItem">Single Item</string>
     <string name="MultiItems">Multi Items</string>
+    <string name="MultiItemsWithOverride">Multi Items With Override</string>
     <string name="AutoComplete">Auto Complete</string>
     <string name="AutoCompleteToken">Auto Complete Token</string>
     <string name="Button">Button</string>

--- a/form/src/main/java/com/thejuki/kformmaster/model/FormPickerMultiCheckBoxElement.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/model/FormPickerMultiCheckBoxElement.kt
@@ -179,38 +179,19 @@ class FormPickerMultiCheckBoxElement<T : List<*>>(tag: Int = -1) : FormPickerEle
         editTextView?.setOnClickListener(listener)
     }
 
-    fun getSelectedItemsText(): String {
-        val options = arrayOfNulls<CharSequence>(this.options?.size ?: 0)
-        val mSelectedItems = ArrayList<Int>()
+    private fun getSelectedItemsText(): String =
+        this.options?.filter { this.value?.contains(it) ?: false }
+                ?.joinToString(", ") { it.toString() } ?: ""
 
-        this.options?.let {
-            for (i in it.indices) {
-                val obj = it[i]
+    var valueAsStringOverride: ((T?) -> String?)? = null
 
-                options[i] = obj.toString()
-
-                if (this.value?.contains(obj) == true) {
-                    mSelectedItems.add(i)
-                }
-            }
-        }
-
-        var selectedItems = ""
-        for (i in mSelectedItems.indices) {
-            selectedItems += options[mSelectedItems[i]]
-
-            if (i < mSelectedItems.size - 1) {
-                selectedItems += ", "
-            }
-        }
-
-        return selectedItems
-    }
+    override val valueAsString
+        get() = valueAsStringOverride?.invoke(value) ?: getSelectedItemsText()
 
     override fun displayNewValue() {
         editView?.let {
             if (it is TextView) {
-                it.text = getSelectedItemsText()
+                it.text = valueAsString
             }
         }
     }

--- a/form/src/main/java/com/thejuki/kformmaster/view/FormPickerMultiCheckBoxViewBinder.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/view/FormPickerMultiCheckBoxViewBinder.kt
@@ -42,7 +42,7 @@ class FormPickerMultiCheckBoxViewBinder(private val context: Context, private va
 
         model.reInitDialog(formBuilder)
         setClearableListener(model)
-        editTextValue.setText(model.getSelectedItemsText())
+        editTextValue.setText(model.valueAsString)
 
     }, object : ViewStateProvider<FormPickerMultiCheckBoxElement<*>, ViewHolder> {
         override fun createViewStateID(model: FormPickerMultiCheckBoxElement<*>): Int {


### PR DESCRIPTION
### Issue Link
This addresses my own feature request [HERE](https://github.com/TheJuki/KFormMaster/issues/187)

### Goals

See the [feature request](https://github.com/TheJuki/KFormMaster/issues/187).

### Implementation Details

 - added a few more fruits and a new `multiCheckBox` block to test activity to illustrate my point, once you get past a certain size it doesn't make sense to show the full list. This is especially evident in some custom layouts, for example I'm stacking the Cell's title and value vertically, similar to how Android's system settings UI these days, where the value will only be in a single line.
  - was trying to follow the code in `getSelectedItemsText()`, seemed a bit long for what its trying to do, so replaced it with a short version with Kotlin collection functions.
  - changed `displayNewValue` back to using `valueAsString` so it seemed more consistent with the rest of the project, and made `getSelectedItemsText()` private.

### Testing Details
Didn't add any new tests.