### PR TITLE
Custom View on alert dialog in FormPickerDropDownElement

### DIFF
--- a/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
+++ b/form/src/main/java/com/thejuki/kformmaster/model/FormPickerDropDownElement.kt
@@ -84,6 +84,8 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
     override val valueAsString: String
         get() = this.displayValueFor(this.value) ?: ""
 
+
+    var dialogTitleCustomView: View? = null
     /**
      * Re-initializes the dialog
      * Should be called after the options list changes
@@ -179,6 +181,10 @@ class FormPickerDropDownElement<T>(tag: Int = -1) : FormPickerElement<T>(tag) {
             }
 
             alertDialog = it.create()
+
+            if (dialogTitleCustomView != null) {
+                alertDialog.setCustomTitle(dialogTitleCustomView)
+            }
         }
 
         // display the dialog on click


### PR DESCRIPTION
### Issue Link
Title view on alert dialog in FormPickerDropDownElement is fixed with 2 maxLines.

### Goals
Allow flexibility in creating custom title view in alert dialog.

### Implementation Details
Adding custom title view into alert dialog in FormPickerDropDownElement.

### Testing Details
Not added any test case, but tested perfectly.

## Note: 
Probably in future can have more flexibility (font-family and so on), this PR I was just amended what I needed so far. 

Thanks you for your great effort in creating such useful library. Your code is so clean that I always want to learn from.


